### PR TITLE
docs(api): add documentation for new record retrieval endpoints

### DIFF
--- a/docs/rest-api/README.md
+++ b/docs/rest-api/README.md
@@ -53,6 +53,7 @@ https://srv.inflowcrm.pl
 ## 🧭 API Overview
 
 - Simple and advanced filtering for all search/count/find endpoints
+- **Record retrieval** by single ID or multiple IDs with pagination
 - Comprehensive support for filter conditions: `equal`, `notEqual`, `greater`, `greaterOrEqual`, `lower`, `lowerOrEqual`, `in`, `notIn`
 - Migration path from simple to advanced filters (backward compatible)
 - Error handling and field compatibility matrix

--- a/docs/rest-api/endpoints.md
+++ b/docs/rest-api/endpoints.md
@@ -15,6 +15,8 @@ This section provides detailed documentation for every public API endpoint, incl
 - [PATCH /api/updateRecordid](#patch-apiupdaterecordid)
 - [POST /api/searchRecords](#post-apisearchrecords)
 - [POST /api/findRecord](#post-apifindrecord)
+- [GET /api/{module}/{id}](#get-apimoduleid)
+- [POST /api/records/getByIds](#post-apirecordsgetbyids)
 - [POST /api/getModuleFields](#post-apigetmodulefields)
 - [POST /api/getSampleData](#post-apigetsampledata)
 - [POST /api/records/count](#post-apirecordscount)
@@ -438,6 +440,136 @@ Finds a single record by filters.
   "meta": { "deprecation": null }
 }
 ```
+
+---
+
+## GET /api/{module}/{id}
+
+Retrieves a single record from a specified module by its ID.
+
+**Headers:**
+`x-api-key: YOUR_API_KEY`
+
+**Path Parameters:**
+- `module` (string, required): Module name (e.g., "customer", "contact", "order") or its translation
+- `id` (string, required): Unique record identifier (MongoDB ObjectId)
+
+**Response (200 OK):**
+```json
+{
+  "data": {
+    "id": "507f1f77bcf86cd799439011",
+    "name": "Jan Kowalski",
+    "email": "jan@example.com"
+  },
+  "meta": {
+    "deprecation": null
+  }
+}
+```
+
+**Error Responses:**
+- **404 Not Found**: Record not found or has been deleted
+- **401 Unauthorized**: Missing or invalid API key
+- **403 Forbidden**: Module not available in your bundle
+
+**Example (curl):**
+```bash
+curl -X GET "https://srv.inflowcrm.pl/api/customer/507f1f77bcf86cd799439011" \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+**Notes:**
+- Automatically filters out deleted records (`deleted: true`)
+- Returns only records belonging to the same tenant (master)
+- Fields are mapped from internal format to API format
+
+---
+
+## POST /api/records/getByIds
+
+Retrieves multiple records from a specified module by a list of IDs. Supports pagination for large datasets.
+
+**Headers:**
+`x-api-key: YOUR_API_KEY`
+`Content-Type: application/json`
+
+**Body:**
+```json
+{
+  "module": "customer",
+  "ids": [
+    "507f1f77bcf86cd799439011",
+    "507f1f77bcf86cd799439012",
+    "507f1f77bcf86cd799439013"
+  ],
+  "page": 1,
+  "limit": 50,
+  "sort": {
+    "createdAt": -1
+  }
+}
+```
+
+**Body Parameters:**
+- `module` (string, required): Module name or its translation
+- `ids` (array of strings, required): Array of record IDs to retrieve
+- `page` (number, optional, default: 1): Page number (min: 1)
+- `limit` (number, optional, default: 50): Records per page (min: 1, max: 200)
+- `sort` (object, optional): Sort criteria, where `1` = ascending, `-1` = descending
+
+**Response (200 OK):**
+```json
+{
+  "data": [
+    {
+      "id": "507f1f77bcf86cd799439011",
+      "name": "Jan Kowalski",
+      "email": "jan@example.com"
+    },
+    {
+      "id": "507f1f77bcf86cd799439012",
+      "name": "Anna Nowak",
+      "email": "anna@example.com"
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "page": 1,
+      "limit": 50,
+      "total": 2,
+      "pages": 1
+    },
+    "deprecation": null
+  }
+}
+```
+
+**Error Responses:**
+- **400 Bad Request**: Invalid parameters (e.g., missing module, empty ids array)
+- **401 Unauthorized**: Missing or invalid API key
+- **403 Forbidden**: Module not available in your bundle
+
+**Example (curl):**
+```bash
+curl -X POST "https://srv.inflowcrm.pl/api/records/getByIds" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "module": "customer",
+    "ids": ["507f1f77bcf86cd799439011", "507f1f77bcf86cd799439012"],
+    "page": 1,
+    "limit": 50,
+    "sort": {"createdAt": -1}
+  }'
+```
+
+**Notes:**
+- Automatically skips non-existent or deleted records
+- Returns only records belonging to the same tenant (master)
+- Pagination allows efficient retrieval of large record sets
+- Maximum limit per page is 200 records
+- Default sort is `{ createdAt: -1 }` if not specified
 
 ---
 

--- a/docs/rest-api/errors.md
+++ b/docs/rest-api/errors.md
@@ -26,7 +26,8 @@ All errors use a consistent format:
 |------|--------------------------|--------------------------------------|
 | 400  | Bad Request              | Validation failed, invalid input     |
 | 401  | Unauthorized             | Missing or invalid API key           |
-| 404  | Not Found                | Resource does not exist              |
+| 403  | Forbidden                | Access to module or resource denied  |
+| 404  | Not Found                | Resource does not exist or deleted   |
 | 409  | Conflict                 | Duplicate or conflicting data        |
 | 415  | Unsupported Media Type   | Wrong content type                   |
 | 422  | Unprocessable Entity     | Semantic validation error            |

--- a/docs/rest-api/openapi.yaml
+++ b/docs/rest-api/openapi.yaml
@@ -377,6 +377,130 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '429':
           $ref: '#/components/responses/RateLimit'
+  /api/{module}/{id}:
+    get:
+      tags: [Records]
+      summary: Get single record by ID
+      operationId: getRecordById
+      security: [{ ApiKeyAuth: [] }]
+      parameters:
+        - name: module
+          in: path
+          required: true
+          description: Module name or translation
+          schema:
+            type: string
+            example: customer
+        - name: id
+          in: path
+          required: true
+          description: Record ID (MongoDB ObjectId)
+          schema:
+            type: string
+            example: 507f1f77bcf86cd799439011
+      responses:
+        '200':
+          description: Single record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimit'
+    delete:
+      tags: [Records]
+      summary: Delete a record
+      operationId: deleteRecord
+      security: [{ ApiKeyAuth: [] }]
+      parameters:
+        - name: module
+          in: path
+          required: true
+          description: Module name
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          description: Record ID
+          schema:
+            type: string
+      responses:
+        '204':
+          description: No Content
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimit'
+  /api/records/getByIds:
+    post:
+      tags: [Records]
+      summary: Get multiple records by IDs with pagination
+      operationId: getRecordsByIds
+      security: [{ ApiKeyAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - module
+                - ids
+              properties:
+                module:
+                  type: string
+                  description: Module name or translation
+                  example: customer
+                ids:
+                  type: array
+                  items:
+                    type: string
+                  description: Array of record IDs
+                  example: ["507f1f77bcf86cd799439011", "507f1f77bcf86cd799439012"]
+                page:
+                  type: integer
+                  minimum: 1
+                  default: 1
+                  description: Page number
+                limit:
+                  type: integer
+                  minimum: 1
+                  maximum: 200
+                  default: 50
+                  description: Records per page
+                sort:
+                  type: object
+                  description: Sort criteria (1 = ascending, -1 = descending)
+                  example: { "createdAt": -1 }
+      responses:
+        '200':
+          description: List of records with pagination
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                  meta:
+                    $ref: '#/components/schemas/Meta'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimit'
   /api/getModuleFields:
     post:
       tags: [Modules]
@@ -457,30 +581,6 @@ paths:
                     $ref: '#/components/schemas/Meta'
         '401':
           $ref: '#/components/responses/Unauthorized'
-  /api/{module}/{id}:
-    delete:
-      tags: [Records]
-      summary: Delete a record (soft delete)
-      operationId: deleteRecord
-      security: [{ ApiKeyAuth: [] }]
-      parameters:
-        - name: module
-          in: path
-          required: true
-          schema: { type: string }
-        - name: id
-          in: path
-          required: true
-          schema: { type: string }
-      responses:
-        '204':
-          description: Record deleted
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '429':
-          $ref: '#/components/responses/RateLimit'
 components:
   schemas:
     SubscribeWebhookRequest:
@@ -779,5 +879,18 @@ components:
                 type: object
                 properties:
                   code: { type: string, example: NOT_FOUND }
+                  message: { type: string }
+                  details: {}
+    Forbidden:
+      description: Forbidden - access to module or resource denied
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  code: { type: string, example: FORBIDDEN }
                   message: { type: string }
                   details: {}


### PR DESCRIPTION
Added comprehensive documentation for two new REST API endpoints:

- GET /api/{module}/{id}: Retrieve single record by ID
  - Returns individual record from specified module
  - Supports module name or translation
  - Automatically filters deleted records
  - Includes tenant isolation

- POST /api/records/getByIds: Bulk record retrieval with pagination
  - Fetch multiple records by ID array
  - Configurable pagination (1-200 records per page)
  - Flexible sorting (ascending/descending)
  - Automatically skips non-existent/deleted records
  - Default sort by createdAt descending

Changes:
- Updated docs/rest-api/endpoints.md with detailed endpoint documentation
- Updated docs/rest-api/README.md API Overview section
- Updated docs/rest-api/errors.md with 403 Forbidden status code
- Updated docs/rest-api/openapi.yaml with OpenAPI 3.0 specifications
- Added Forbidden response component to OpenAPI spec
- Consolidated duplicate DELETE endpoint definition

Both endpoints include:
- Complete request/response examples
- Error handling documentation (400, 401, 403, 404)
- cURL examples
- Rate limiting information
- Authentication requirements